### PR TITLE
Remove URL2PNG from the README

### DIFF
--- a/README
+++ b/README
@@ -1,5 +1,3 @@
-URL2PNG
-
 PHP Codeigniter library for ShrinkTheWeb.com - API for generating website thumbnails
 
 # Usage #


### PR DESCRIPTION
Why was it added in the first place?
